### PR TITLE
Add frontend maintenance flag for JackpotV2

### DIFF
--- a/src/components/tabs/JackPotV2.tsx
+++ b/src/components/tabs/JackPotV2.tsx
@@ -8,7 +8,7 @@ import { Button } from "~/components/ui/Button";
 import { toast } from "sonner";
 import { formatDistanceToNow, format } from "date-fns";
 import { useAccount, usePublicClient, useSendTransaction } from "wagmi";
-import { CELO_JACKPOTV2_ADDRESS, CELO_JACKPOTV2_ABI, MOTIVATIONAL_STATEMENTS } from "~/lib/constants";
+import { CELO_JACKPOTV2_ADDRESS, CELO_JACKPOTV2_ABI, CELO_JACKPOTV2_MAINTENANCE, MOTIVATIONAL_STATEMENTS } from "~/lib/constants";
 import { encodeFunctionData, parseEther, formatEther, parseUnits } from "viem";
 import { getDataSuffix, submitReferral } from "@divvi/referral-sdk";
 import { Input } from "../ui/input";
@@ -66,6 +66,7 @@ const [isDataLoading, setIsDataLoading] = useState(false); // Renamed for clarit
 const countdownRef = useRef<NodeJS.Timeout>();
 const [drawDate, setDrawDate] = useState<string>("TBD");
 const [pastRounds, setPastRounds] = useState<RoundData[]>([]);
+const maintenanceMode = CELO_JACKPOTV2_MAINTENANCE;
   
 
   // Fetch dashboard data and user-specific data
@@ -220,6 +221,10 @@ const fetchPastRounds = useCallback(async () => {
   }, [fetchDashboardData,fetchPastRounds]);
 
   const handleTriggerDraw = async () => {
+  if (maintenanceMode) {
+    toast.warning("Jackpot is currently under maintenance.");
+    return;
+  }
   if (!address || !publicClient || !isCorrectChain) {
     toast.error("Wallet not connected or wrong network");
     return;
@@ -262,6 +267,10 @@ const formatCountdown = (seconds: number): string => {
 };
 
   const handleBuyTickets = async () => {
+    if (maintenanceMode) {
+      toast.warning("Jackpot is currently under maintenance.");
+      return;
+    }
     if (!address || !publicClient || !isCorrectChain) {
       toast.error("Wallet not connected or wrong network");
       return;
@@ -344,6 +353,10 @@ const formatCountdown = (seconds: number): string => {
   };
 
   const handleClaimWinnings = async (roundId: number) => {
+    if (maintenanceMode) {
+      toast.warning("Jackpot is currently under maintenance.");
+      return;
+    }
     if (!address || !publicClient || !isCorrectChain) {
       toast.error("Wallet not connected or wrong network");
       return;
@@ -462,10 +475,14 @@ useEffect(() => {
             Please switch to Celo Network to proceed
           </p>
         </div>
+      ) : maintenanceMode ? (
+        <div className="p-4 bg-yellow-50 dark:bg-yellow-900/30 rounded-lg text-yellow-800 dark:text-yellow-200 text-center">
+          Jackpot is currently under maintenance. Please check back later.
+        </div>
       ) : (
         <>
           {/* Jackpot Banner */}
-          <motion.div 
+          <motion.div
             initial={{ scale: 0.95 }}
             animate={{ scale: 1 }}
             transition={{ duration: 0.3 }}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2788,6 +2788,7 @@ export const CELO_JACKPOT_ABI=[
   ]
 
 export const CELO_JACKPOTV2_ADDRESS ="0xB6cF643d413D055a467cDd4a4224047831dD92b2"
+export const CELO_JACKPOTV2_MAINTENANCE = true
 export const CELO_JACKPOTV2_ABI = [
     {
       "inputs": [


### PR DESCRIPTION
## Summary
- revert contract changes
- expose a frontend constant to toggle Jackpot V2 maintenance
- show a maintenance banner in the Jackpot V2 page and block actions when enabled
- set Jackpot V2 to be under maintenance
- if maintenance mode is active, hide jackpot UI except banner

## Testing
- `npx hardhat compile` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6857625c100c832897d7dd4c59ed23aa