### PR TITLE
Add basic multi-chain mode toggle

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { FrameProvider } from "~/components/providers/FrameProvider";
 import { ConvexClientProvider } from "./ConvexClientProvider";
+import { ChainProvider } from "~/components/providers/ChainContext";
 
 const WagmiProvider = dynamic(
   () => import("~/components/providers/WagmiProvider"),
@@ -22,11 +23,13 @@ export function Providers({
 }) {
   return (
     <SessionProvider session={session}>
-      <WagmiProvider>
-        <FrameProvider>
-          <ConvexClientProvider>{children}</ConvexClientProvider>
-        </FrameProvider>
-      </WagmiProvider>
+      <ChainProvider>
+        <WagmiProvider>
+          <FrameProvider>
+            <ConvexClientProvider>{children}</ConvexClientProvider>
+          </FrameProvider>
+        </WagmiProvider>
+      </ChainProvider>
     </SessionProvider>
   );
 }

--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -16,6 +16,8 @@ interface HeaderProps {
   onDisconnect: () => void;
   onSignOut: () => void;
   onSwitchChain: () => void;
+  mode: "celo" | "degen";
+  onToggleMode: () => void;
 }
 
 export default function Header({
@@ -30,6 +32,8 @@ export default function Header({
   onDisconnect,
   onSignOut,
   onSwitchChain,
+  mode,
+  onToggleMode,
 }: HeaderProps) {
   return (
     <motion.div
@@ -75,6 +79,12 @@ export default function Header({
               <Wallet className="w-4 h-4 mr-1" /> Connect
             </Button>
           )}
+          <button
+            onClick={onToggleMode}
+            className="text-xs px-2 py-1 rounded-full border"
+          >
+            {mode === "celo" ? "Celo" : "Degen"}
+          </button>
         </div>
       </div>
 
@@ -106,7 +116,7 @@ export default function Header({
             ) : (
               <ArrowLeftRight className="w-4 h-4" />
             )}
-            Switch to Celo
+            Switch to {mode === "celo" ? "Celo" : "Base"}
           </Button>
         </motion.div>
       )}

--- a/src/components/main/hook/useMain.tsx
+++ b/src/components/main/hook/useMain.tsx
@@ -2,10 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { usePublicClient } from "wagmi";
 import { formatEther } from "viem";
 import { toast } from "sonner";
-import {
-  BANK_OF_CELO_CONTRACT_ABI,
-  BANK_OF_CELO_CONTRACT_ADDRESS,
-} from "~/lib/constants";
+import { Abi } from "viem";
 
 interface VaultStatus {
   currentBalance: string;
@@ -26,6 +23,8 @@ interface UseContractDataResult {
 export function useContractData(
   address: string | undefined,
   isCorrectChain: boolean,
+  contractAddress: `0x${string}`,
+  contractAbi: Abi,
 ): UseContractDataResult {
   const publicClient = usePublicClient();
   const [vaultBalance, setVaultBalance] = useState<string>("0");
@@ -44,24 +43,24 @@ export function useContractData(
     try {
       const data = await Promise.all([
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: contractAddress,
+          abi: contractAbi,
           functionName: "getVaultStatus",
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: contractAddress,
+          abi: contractAbi,
           functionName: "claimCooldown",
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: contractAddress,
+          abi: contractAbi,
           functionName: "lastClaimAt",
           args: [address],
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: contractAddress,
+          abi: contractAbi,
           functionName: "MAX_CLAIM",
         }),
       ]);

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -21,8 +21,11 @@ import { toast } from "sonner";
 import {
   BANK_OF_CELO_CONTRACT_ABI,
   BANK_OF_CELO_CONTRACT_ADDRESS,
+  BANK_OF_DEGEN_ADDRESS,
+  BANK_OF_DEGEN_ABI,
 } from "~/lib/constants";
-import { celo } from "viem/chains";
+
+import { useChain } from "~/components/providers/ChainContext";
 import { getDataSuffix, submitReferral } from "@divvi/referral-sdk";
 import { cubesImage } from "~/constants/images";
 import { useContractData } from "./hook/useMain";
@@ -44,6 +47,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const { writeContract, isPending } = useWriteContract();
   const { isSDKLoaded, context } = useFrame();
   const searchParams = useSearchParams();
+  const { chain: targetChain, mode, toggleMode } = useChain();
 
   const [customSearchParams, setCustomSearchParams] =
     useState<URLSearchParams | null>(null);
@@ -52,12 +56,14 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const [activeTab, setActiveTab] = useState("home");
 
   const chainId = useChainId();
-  const CELO_CHAIN_ID = celo.id;
-  const targetChain = celo;
-  const isCorrectChain = chain?.id === CELO_CHAIN_ID;
+  const isCorrectChain = chain?.id === targetChain.id;
   const showSwitchNetworkBanner = isConnected && !isCorrectChain;
 
   // Use our custom hooks
+  const bankAddress =
+    mode === "celo" ? BANK_OF_CELO_CONTRACT_ADDRESS : BANK_OF_DEGEN_ADDRESS;
+  const bankAbi = mode === "celo" ? BANK_OF_CELO_CONTRACT_ABI : BANK_OF_DEGEN_ABI;
+
   const {
     vaultBalance,
     vaultStatus,
@@ -66,7 +72,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
     maxClaim,
     isLoading,
     fetchContractData,
-  } = useContractData(address, isCorrectChain);
+  } = useContractData(address, isCorrectChain, bankAddress, bankAbi);
 
   const { showWelcome, setShowWelcome, handleCloseWelcome } = useWelcomeModal();
 
@@ -132,9 +138,9 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
       connectors.find((c) => c.id === "injected") || connectors[0];
     connect({
       connector,
-      chainId: CELO_CHAIN_ID,
+      chainId: targetChain.id,
     });
-  }, [connectors, connect, CELO_CHAIN_ID]);
+  }, [connectors, connect, targetChain]);
 
   const handleSignOut = useCallback(async () => {
     await signOut({ redirect: false });
@@ -188,10 +194,10 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
         // 4. Send the transaction
         const hash = await sendTransactionAsync({
-          to: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
+          to: bankAddress as `0x${string}`,
           data: combinedData as `0x${string}`,
           value: parseEther(amount),
-          chainId: CELO_CHAIN_ID,
+          chainId: targetChain.id,
           maxFeePerGas: parseUnits("100", 9),
           maxPriorityFeePerGas: parseUnits("100", 9),
         });
@@ -206,11 +212,11 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         try {
           console.log("Submitting referral to Divi:", {
             txHash: hash,
-            chainId: CELO_CHAIN_ID,
+            chainId: targetChain.id,
           });
           await submitReferral({
             txHash: hash,
-            chainId: CELO_CHAIN_ID,
+            chainId: targetChain.id,
           });
           console.log("Referral submitted successfully");
         } catch (diviError) {
@@ -226,7 +232,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         );
       }
     },
-    [isCorrectChain, sendTransactionAsync, CELO_CHAIN_ID, fetchContractData],
+    [isCorrectChain, sendTransactionAsync, targetChain.id, fetchContractData],
   );
 
   // Show loading spinner if SDK is not loaded
@@ -272,6 +278,8 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         onDisconnect={() => disconnect()}
         onSignOut={handleSignOut}
         onSwitchChain={handleSwitchChain}
+        mode={mode}
+        onToggleMode={toggleMode}
       />
 
       {/* Content */}

--- a/src/components/providers/ChainContext.tsx
+++ b/src/components/providers/ChainContext.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { celo, base, type Chain } from "wagmi/chains";
+
+export type ChainMode = "celo" | "degen";
+
+interface ChainContextValue {
+  mode: ChainMode;
+  chain: Chain;
+  toggleMode: () => void;
+}
+
+const ChainContext = createContext<ChainContextValue | undefined>(undefined);
+
+export function ChainProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<ChainMode>("celo");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("chainMode");
+    if (stored === "degen" || stored === "celo") {
+      setMode(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("chainMode", mode);
+  }, [mode]);
+
+  const toggleMode = () => setMode((m) => (m === "celo" ? "degen" : "celo"));
+
+  const chain = mode === "celo" ? celo : base;
+
+  return (
+    <ChainContext.Provider value={{ mode, chain, toggleMode }}>
+      {children}
+    </ChainContext.Provider>
+  );
+}
+
+export function useChain() {
+  const ctx = useContext(ChainContext);
+  if (!ctx) throw new Error("useChain must be used within ChainProvider");
+  return ctx;
+}

--- a/src/components/providers/WagmiProvider.tsx
+++ b/src/components/providers/WagmiProvider.tsx
@@ -1,5 +1,5 @@
 import { createConfig, http, WagmiProvider } from "wagmi";
-import { celo } from "wagmi/chains";
+import { celo, base } from "wagmi/chains";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { farcasterFrame } from "@farcaster/frame-wagmi-connector";
 import { coinbaseWallet, metaMask, walletConnect } from "wagmi/connectors";
@@ -43,9 +43,10 @@ function useCoinbaseWalletAutoConnect() {
 }
 
 export const config = createConfig({
-  chains: [celo],
+  chains: [celo, base],
   transports: {
     [celo.id]: http(),
+    [base.id]: http(),
   },
   connectors: [
     farcasterFrame(),

--- a/src/components/ui/ModeToggle.tsx
+++ b/src/components/ui/ModeToggle.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useChain } from "~/components/providers/ChainContext";
+
+export default function ModeToggle() {
+  const { mode, toggleMode } = useChain();
+  return (
+    <button
+      onClick={toggleMode}
+      className="px-2 py-1 text-xs font-medium rounded-full border"
+    >
+      {mode === "celo" ? "Celo" : "Degen"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ChainContext` provider for tracking chain mode
- update `WagmiProvider` with Celo and Base chains
- expose a toggle in the header to switch modes
- fetch contract data based on selected chain

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e963db1208328b52a050d79c6a877