### PR TITLE
Add chain mode toggle and dynamic chain support

### DIFF
--- a/src/app/chain-mode/context.tsx
+++ b/src/app/chain-mode/context.tsx
@@ -1,0 +1,44 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Mode = "celo" | "degen";
+
+interface ChainModeContextValue {
+  mode: Mode;
+  toggleMode: () => void;
+  setMode: (m: Mode) => void;
+}
+
+const ChainModeContext = createContext<ChainModeContextValue | undefined>(undefined);
+
+export function ChainModeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setModeState] = useState<Mode>("celo");
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem("chainMode") : null;
+    if (stored === "celo" || stored === "degen") setModeState(stored);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("chainMode", mode);
+      document.documentElement.classList.toggle("degen-mode", mode === "degen");
+      document.documentElement.classList.toggle("celo-mode", mode === "celo");
+    }
+  }, [mode]);
+
+  const setMode = (m: Mode) => setModeState(m);
+  const toggleMode = () => setModeState((p) => (p === "celo" ? "degen" : "celo"));
+
+  return (
+    <ChainModeContext.Provider value={{ mode, toggleMode, setMode }}>
+      {children}
+    </ChainModeContext.Provider>
+  );
+}
+
+export function useChainMode() {
+  const ctx = useContext(ChainModeContext);
+  if (!ctx) throw new Error("useChainMode must be used within ChainModeProvider");
+  return ctx;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,13 +5,35 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #fbcc5c;
+  --primary-hover: #e0ae32;
+  --gradient-from: #35d07f;
+  --gradient-to: #fbcc5c;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --primary: #fbcc5c;
+    --primary-hover: #e0ae32;
+    --gradient-from: #35d07f;
+    --gradient-to: #fbcc5c;
   }
+}
+
+html.degen-mode {
+  --primary: #7c65c1;
+  --primary-hover: #6952a3;
+  --gradient-from: #a855f7;
+  --gradient-to: #7c65c1;
+}
+
+html.celo-mode {
+  --primary: #fbcc5c;
+  --primary-hover: #e0ae32;
+  --gradient-from: #35d07f;
+  --gradient-to: #fbcc5c;
 }
 
 body {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { FrameProvider } from "~/components/providers/FrameProvider";
 import { ConvexClientProvider } from "./ConvexClientProvider";
+import { ChainModeProvider } from "./chain-mode/context";
 
 const WagmiProvider = dynamic(
   () => import("~/components/providers/WagmiProvider"),
@@ -23,9 +24,11 @@ export function Providers({
   return (
     <SessionProvider session={session}>
       <WagmiProvider>
-        <FrameProvider>
-          <ConvexClientProvider>{children}</ConvexClientProvider>
-        </FrameProvider>
+        <ChainModeProvider>
+          <FrameProvider>
+            <ConvexClientProvider>{children}</ConvexClientProvider>
+          </FrameProvider>
+        </ChainModeProvider>
       </WagmiProvider>
     </SessionProvider>
   );

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -43,11 +43,9 @@ import HomeTab from "~/components/tabs/HomeTab";
 import TransactTab from "~/components/tabs/TransactTab";
 import SwapBridgeTab from "~/components/tabs/SwapBridgeTab";
 import { truncateAddress } from "~/lib/truncateAddress";
-import {
-  BANK_OF_CELO_CONTRACT_ABI,
-  BANK_OF_CELO_CONTRACT_ADDRESS,
-} from "~/lib/constants";
-import { celo } from "viem/chains";
+import { useBankContract } from "~/hooks/contracts";
+import { useChainMode } from "~/app/chain-mode/context";
+import { celo, base } from "viem/chains";
 import { getDataSuffix, submitReferral } from "@divvi/referral-sdk";
 import { cubesImage } from "~/constants/images";
 import { cn } from "~/lib/utils";
@@ -79,10 +77,11 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
     availableForClaims: "0",
   });
 
+  const { mode } = useChainMode();
+  const { address: bankAddress, abi: bankAbi } = useBankContract();
   const chainId = useChainId();
-  const CELO_CHAIN_ID = celo.id;
-  const targetChain = celo;
-  const isCorrectChain = chain?.id === CELO_CHAIN_ID;
+  const targetChain = mode === "degen" ? base : celo;
+  const isCorrectChain = chain?.id === targetChain.id;
   const showSwitchNetworkBanner = isConnected && !isCorrectChain;
 
   console.log("Current chain ID:", chainId);
@@ -104,24 +103,24 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
     try {
       const data = await Promise.all([
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "getVaultStatus",
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "claimCooldown",
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "lastClaimAt",
           args: [address],
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "MAX_CLAIM",
         }),
       ]);
@@ -205,7 +204,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
   const handleDonate = async (amount: string) => {
     if (!isCorrectChain) {
-      toast.error("Please switch to Celo Network");
+      toast.error(`Please switch to ${targetChain.name} Network`);
       return;
     }
 
@@ -217,7 +216,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
     try {
       // 1. Encode the donate function call
       const donateData = encodeFunctionData({
-        abi: BANK_OF_CELO_CONTRACT_ABI,
+        abi: bankAbi,
         functionName: "donate",
       });
 
@@ -239,10 +238,10 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
       // 4. Send the transaction
       const hash = await sendTransactionAsync({
-        to: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
+        to: bankAddress as `0x${string}`,
         data: combinedData as `0x${string}`,
         value: parseEther(amount),
-        chainId: CELO_CHAIN_ID,
+        chainId: targetChain.id,
         maxFeePerGas: parseUnits("100", 9),
         maxPriorityFeePerGas: parseUnits("100", 9),
       });
@@ -255,14 +254,14 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
       // 6. Report to Divi in a separate try-catch
       try {
-        console.log("Submitting referral to Divi:", {
-          txHash: hash,
-          chainId: CELO_CHAIN_ID,
-        });
-        await submitReferral({
-          txHash: hash,
-          chainId: CELO_CHAIN_ID,
-        });
+          console.log("Submitting referral to Divi:", {
+            txHash: hash,
+            chainId: targetChain.id,
+          });
+          await submitReferral({
+            txHash: hash,
+            chainId: targetChain.id,
+          });
         console.log("Referral submitted successfully");
       } catch (diviError) {
         console.error("Divi submitReferral error:", diviError);
@@ -284,7 +283,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
       connectors.find((c) => c.id === "injected") || connectors[0]; // Prefer injected (MetaMask) or fallback
     connect({
       connector,
-      chainId: CELO_CHAIN_ID,
+      chainId: targetChain.id,
     });
   };
 

--- a/src/components/chain/ChainModeToggle.tsx
+++ b/src/components/chain/ChainModeToggle.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useSwitchChain, useChainId } from "wagmi";
+import { base } from "wagmi/chains";
+import { celo } from "wagmi/chains";
+import { useChainMode } from "~/app/chain-mode/context";
+
+export default function ChainModeToggle() {
+  const { mode, toggleMode } = useChainMode();
+  const { switchChain } = useSwitchChain();
+  const chainId = useChainId();
+
+  const handleToggle = () => {
+    const next = mode === "celo" ? "degen" : "celo";
+    toggleMode();
+    const target = next === "degen" ? base : celo;
+    if (chainId !== target.id) {
+      try {
+        switchChain({ chainId: target.id });
+      } catch (err) {
+        console.error("Failed to switch chain", err);
+      }
+    }
+  };
+
+  return (
+    <button
+      onClick={handleToggle}
+      className="text-xs px-2 py-1 rounded-full border border-gray-300 dark:border-gray-600"
+    >
+      {mode === "celo" ? "Celo Mode" : "Degen Mode"}
+    </button>
+  );
+}

--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -3,6 +3,9 @@ import { Wallet, LogOut, AlertCircle, ArrowLeftRight } from "lucide-react";
 import { Button } from "~/components/ui/Button";
 import { truncateAddress } from "~/lib/truncateAddress";
 import { cn } from "~/lib/utils";
+import ChainModeToggle from "../chain/ChainModeToggle";
+import { useChainMode } from "~/app/chain-mode/context";
+import { celo, base } from "wagmi/chains";
 
 interface HeaderProps {
   title: string;
@@ -31,6 +34,8 @@ export default function Header({
   onSignOut,
   onSwitchChain,
 }: HeaderProps) {
+  const { mode } = useChainMode();
+  const targetChain = mode === "degen" ? base : celo;
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -42,7 +47,7 @@ export default function Header({
       )}
     >
       <div className="flex items-center justify-between mx-0 md:mx-20">
-        <h1 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-emerald-600 to-amber-500">
+        <h1 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)]">
           {title}
         </h1>
         <div className="flex items-center gap-2">
@@ -50,7 +55,7 @@ export default function Header({
             <>
               <Button
                 onClick={onDisconnect}
-                className="text-xs text-black font-medium flex hover:bg-gray-200 bg-gradient-to-r from-emerald-600 to-amber-500 rounded-full px-3 py-1.5"
+                className="text-xs text-black font-medium flex hover:bg-gray-200 bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] rounded-full px-3 py-1.5"
                 aria-label="Disconnect wallet"
               >
                 <Wallet className="w-4 h-4 mr-1" />
@@ -69,12 +74,13 @@ export default function Header({
           ) : (
             <Button
               onClick={onConnect}
-              className="text-xs text-black font-medium flex hover:bg-gray-200 bg-gradient-to-r from-emerald-600 to-amber-500 rounded-full px-3 py-1.5"
+              className="text-xs text-black font-medium flex hover:bg-gray-200 bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] rounded-full px-3 py-1.5"
               aria-label="Connect wallet"
             >
               <Wallet className="w-4 h-4 mr-1" /> Connect
             </Button>
           )}
+          <ChainModeToggle />
         </div>
       </div>
 
@@ -106,7 +112,7 @@ export default function Header({
             ) : (
               <ArrowLeftRight className="w-4 h-4" />
             )}
-            Switch to Celo
+            Switch to {targetChain.name}
           </Button>
         </motion.div>
       )}

--- a/src/components/main/hook/useMain.tsx
+++ b/src/components/main/hook/useMain.tsx
@@ -2,10 +2,8 @@ import { useState, useEffect, useCallback } from "react";
 import { usePublicClient } from "wagmi";
 import { formatEther } from "viem";
 import { toast } from "sonner";
-import {
-  BANK_OF_CELO_CONTRACT_ABI,
-  BANK_OF_CELO_CONTRACT_ADDRESS,
-} from "~/lib/constants";
+
+import { useBankContract } from "~/hooks/contracts";
 
 interface VaultStatus {
   currentBalance: string;
@@ -28,6 +26,7 @@ export function useContractData(
   isCorrectChain: boolean,
 ): UseContractDataResult {
   const publicClient = usePublicClient();
+  const { address: bankAddress, abi: bankAbi } = useBankContract();
   const [vaultBalance, setVaultBalance] = useState<string>("0");
   const [isLoading, setIsLoading] = useState(false);
   const [claimCooldown, setClaimCooldown] = useState<number>(0);
@@ -44,24 +43,24 @@ export function useContractData(
     try {
       const data = await Promise.all([
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "getVaultStatus",
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "claimCooldown",
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "lastClaimAt",
           args: [address],
         }),
         publicClient.readContract({
-          address: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          address: bankAddress as `0x${string}`,
+          abi: bankAbi,
           functionName: "MAX_CLAIM",
         }),
       ]);

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -11,6 +11,7 @@ import {
   useChainId,
   useSendTransaction,
   useWriteContract,
+  usePublicClient,
 } from "wagmi";
 import { useSession } from "next-auth/react";
 import { signOut } from "next-auth/react";
@@ -18,11 +19,8 @@ import sdk from "@farcaster/frame-sdk";
 import { encodeFunctionData, parseEther, parseUnits } from "viem";
 import { useFrame } from "~/components/providers/FrameProvider";
 import { toast } from "sonner";
-import {
-  BANK_OF_CELO_CONTRACT_ABI,
-  BANK_OF_CELO_CONTRACT_ADDRESS,
-} from "~/lib/constants";
-import { celo } from "viem/chains";
+import { useBankContract, ERC20_ABI } from "~/hooks/contracts";
+import { celo, base } from "viem/chains";
 import { getDataSuffix, submitReferral } from "@divvi/referral-sdk";
 import { cubesImage } from "~/constants/images";
 import { useContractData } from "./hook/useMain";
@@ -33,6 +31,7 @@ import Header from "./Header";
 import TabContent from "./TabContent";
 import BottomNavigation from "./BottomNavigation";
 import { useSearchParams } from "next/navigation";
+import { useChainMode } from "~/app/chain-mode/context";
 
 export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const { address, isConnected, chain } = useAccount();
@@ -42,6 +41,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const { data: session, status } = useSession();
   const { sendTransactionAsync } = useSendTransaction();
   const { writeContract, isPending } = useWriteContract();
+  const publicClient = usePublicClient();
   const { isSDKLoaded, context } = useFrame();
   const searchParams = useSearchParams();
 
@@ -51,10 +51,12 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
   const [activeTab, setActiveTab] = useState("home");
 
+  const { mode } = useChainMode();
+  const dynamicTitle = mode === "degen" ? "Bank of Degen" : title;
+  const { address: bankAddress, abi: bankAbi } = useBankContract();
   const chainId = useChainId();
-  const CELO_CHAIN_ID = celo.id;
-  const targetChain = celo;
-  const isCorrectChain = chain?.id === CELO_CHAIN_ID;
+  const targetChain = mode === "degen" ? base : celo;
+  const isCorrectChain = chain?.id === targetChain.id;
   const showSwitchNetworkBanner = isConnected && !isCorrectChain;
 
   // Use our custom hooks
@@ -132,9 +134,9 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
       connectors.find((c) => c.id === "injected") || connectors[0];
     connect({
       connector,
-      chainId: CELO_CHAIN_ID,
+      chainId: targetChain.id,
     });
-  }, [connectors, connect, CELO_CHAIN_ID]);
+  }, [connectors, connect, targetChain]);
 
   const handleSignOut = useCallback(async () => {
     await signOut({ redirect: false });
@@ -154,7 +156,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const handleDonate = useCallback(
     async (amount: string) => {
       if (!isCorrectChain) {
-        toast.error("Please switch to Celo Network");
+        toast.error(`Please switch to ${targetChain.name} Network`);
         return;
       }
 
@@ -164,9 +166,45 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
       }
 
       try {
+        if (mode === "degen" && address) {
+          const tokenAddress = (await publicClient.readContract({
+            address: bankAddress as `0x${string}`,
+            abi: bankAbi,
+            functionName: "degenToken",
+          })) as `0x${string}`;
+          const decimals = (await publicClient.readContract({
+            address: tokenAddress,
+            abi: ERC20_ABI,
+            functionName: "decimals",
+          })) as number;
+          const amountParsed = parseUnits(amount, decimals);
+          const allowance = (await publicClient.readContract({
+            address: tokenAddress,
+            abi: ERC20_ABI,
+            functionName: "allowance",
+            args: [address, bankAddress],
+          })) as bigint;
+          if (allowance < amountParsed) {
+            await writeContract({
+              address: tokenAddress,
+              abi: ERC20_ABI,
+              functionName: "approve",
+              args: [bankAddress, amountParsed],
+            });
+          }
+          await writeContract({
+            address: bankAddress,
+            abi: bankAbi,
+            functionName: "donate",
+            args: [amountParsed],
+          });
+          toast.success("Donation successful!");
+          fetchContractData();
+          return;
+        }
         // 1. Encode the donate function call
         const donateData = encodeFunctionData({
-          abi: BANK_OF_CELO_CONTRACT_ABI,
+          abi: bankAbi,
           functionName: "donate",
         });
 
@@ -188,10 +226,10 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
         // 4. Send the transaction
         const hash = await sendTransactionAsync({
-          to: BANK_OF_CELO_CONTRACT_ADDRESS as `0x${string}`,
+          to: bankAddress as `0x${string}`,
           data: combinedData as `0x${string}`,
           value: parseEther(amount),
-          chainId: CELO_CHAIN_ID,
+          chainId: targetChain.id,
           maxFeePerGas: parseUnits("100", 9),
           maxPriorityFeePerGas: parseUnits("100", 9),
         });
@@ -206,11 +244,11 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         try {
           console.log("Submitting referral to Divi:", {
             txHash: hash,
-            chainId: CELO_CHAIN_ID,
+            chainId: targetChain.id,
           });
           await submitReferral({
             txHash: hash,
-            chainId: CELO_CHAIN_ID,
+            chainId: targetChain.id,
           });
           console.log("Referral submitted successfully");
         } catch (diviError) {
@@ -226,7 +264,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         );
       }
     },
-    [isCorrectChain, sendTransactionAsync, CELO_CHAIN_ID, fetchContractData],
+    [isCorrectChain, sendTransactionAsync, targetChain.id, fetchContractData],
   );
 
   // Show loading spinner if SDK is not loaded
@@ -236,7 +274,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
   return (
     <div
-      className="min-h-screen bg-gradient-to-br from-emerald-100 via-amber-50 to-emerald-100 dark:from-emerald-950 dark:via-gray-900 dark:to-emerald-950 flex flex-col"
+      className="min-h-screen bg-gradient-to-br from-[var(--gradient-from)] via-white to-[var(--gradient-to)] dark:from-neutral-900 dark:via-neutral-900 dark:to-neutral-900 flex flex-col"
       style={{
         paddingTop: context?.client.safeAreaInsets?.top ?? 0,
         paddingBottom: context?.client.safeAreaInsets?.bottom ?? 60,
@@ -261,7 +299,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
 
       {/* Header */}
       <Header
-        title={title}
+        title={dynamicTitle}
         isConnected={isConnected}
         address={address}
         status={status}

--- a/src/components/providers/WagmiProvider.tsx
+++ b/src/components/providers/WagmiProvider.tsx
@@ -1,5 +1,5 @@
 import { createConfig, http, WagmiProvider } from "wagmi";
-import { celo } from "wagmi/chains";
+import { celo, base } from "wagmi/chains";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { farcasterFrame } from "@farcaster/frame-wagmi-connector";
 import { coinbaseWallet, metaMask, walletConnect } from "wagmi/connectors";
@@ -43,9 +43,10 @@ function useCoinbaseWalletAutoConnect() {
 }
 
 export const config = createConfig({
-  chains: [celo],
+  chains: [celo, base],
   transports: {
     [celo.id]: http(),
+    [base.id]: http(),
   },
   connectors: [
     farcasterFrame(),

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,7 +11,7 @@ export function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`w-full max-w-xs mx-auto block bg-[#7C65C1] text-white py-3 px-6 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[#7C65C1] hover:bg-[#6952A3] ${className}`}
+      className={`w-full max-w-xs mx-auto block bg-[color:var(--primary)] text-white py-3 px-6 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-[color:var(--primary)] hover:bg-[color:var(--primary-hover)] ${className}`}
       {...props}
     >
       {isLoading ? (

--- a/src/hooks/contracts.ts
+++ b/src/hooks/contracts.ts
@@ -1,0 +1,42 @@
+import { useChainMode } from "~/app/chain-mode/context";
+import {
+  BANK_OF_CELO_CONTRACT_ADDRESS,
+  BANK_OF_CELO_CONTRACT_ABI,
+  CELO_CHECK_IN_CONTRACT_ADDRESS,
+  CELO_CHECK_IN_ABI,
+  CELO_JACKPOT_CONTRACT_ADDRESS,
+  CELO_JACKPOT_ABI,
+  BANK_OF_DEGEN_ADDRESS,
+  BANK_OF_DEGEN_ABI,
+  DEGEN_DAILY_CHECKIN_ADDRESS,
+  DEGEN_DAILY_CHECKIN_ABI,
+  DEGEN_JACKPOT_ADDRESS,
+  DEGEN_JACKPOT_ABI,
+} from "~/lib/constants";
+
+export const ERC20_ABI = [
+  { inputs: [], name: "decimals", outputs: [{ type: "uint8" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "owner", type: "address" }, { name: "spender", type: "address" }], name: "allowance", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" },
+  { inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }], name: "approve", outputs: [{ type: "bool" }], stateMutability: "nonpayable", type: "function" },
+];
+
+export function useBankContract() {
+  const { mode } = useChainMode();
+  return mode === "degen"
+    ? { address: BANK_OF_DEGEN_ADDRESS, abi: BANK_OF_DEGEN_ABI }
+    : { address: BANK_OF_CELO_CONTRACT_ADDRESS, abi: BANK_OF_CELO_CONTRACT_ABI };
+}
+
+export function useCheckinContract() {
+  const { mode } = useChainMode();
+  return mode === "degen"
+    ? { address: DEGEN_DAILY_CHECKIN_ADDRESS, abi: DEGEN_DAILY_CHECKIN_ABI }
+    : { address: CELO_CHECK_IN_CONTRACT_ADDRESS, abi: CELO_CHECK_IN_ABI };
+}
+
+export function useJackpotContract() {
+  const { mode } = useChainMode();
+  return mode === "degen"
+    ? { address: DEGEN_JACKPOT_ADDRESS, abi: DEGEN_JACKPOT_ABI }
+    : { address: CELO_JACKPOT_CONTRACT_ADDRESS, abi: CELO_JACKPOT_ABI };
+}


### PR DESCRIPTION
## Summary
- implement `ChainModeProvider` to store Celo/Degen mode
- add `ChainModeToggle` UI and dynamic gradient colors
- support Base network in wagmi provider
- provide hooks for contracts depending on selected mode
- update donation flow with ERC20 approve logic

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ea644fd188328bec5919f9f8e430c