### PR TITLE
Implement degen mode visuals

### DIFF
--- a/public/assets/images/degen-logo.svg
+++ b/public/assets/images/degen-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#7c65c1" />
+  <text x="50" y="55" text-anchor="middle" font-size="60" font-family="Arial" fill="white" dy=".3em">D</text>
+</svg>

--- a/src/components/main/BottomNavigation.tsx
+++ b/src/components/main/BottomNavigation.tsx
@@ -34,8 +34,8 @@ export default function BottomNavigation({
           onClick={() => onTabChange(tab.id)}
           className={`relative flex flex-col items-center p-2 rounded-xl transition-all ${
             activeTab === tab.id
-              ? "text-white bg-gradient-to-r from-emerald-500 to-emerald-600 shadow-md"
-              : "text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400"
+              ? "text-white bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] shadow-md"
+              : "text-gray-600 dark:text-gray-300 hover:text-[var(--primary)]"
           }`}
           aria-label={tab.label}
         >
@@ -44,7 +44,7 @@ export default function BottomNavigation({
           {activeTab === tab.id && (
             <motion.div
               layoutId="activeTabIndicator"
-              className="absolute bottom-0 w-1/2 h-1 bg-emerald-300 rounded-full"
+              className="absolute bottom-0 w-1/2 h-1 bg-[var(--primary)]/70 rounded-full"
             />
           )}
         </button>

--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -36,6 +36,10 @@ export default function Header({
 }: HeaderProps) {
   const { mode } = useChainMode();
   const targetChain = mode === "degen" ? base : celo;
+  const logoSrc =
+    mode === "degen"
+      ? "/assets/images/degen-logo.svg"
+      : "/assets/images/celo-image.png";
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -47,7 +51,12 @@ export default function Header({
       )}
     >
       <div className="flex items-center justify-between mx-0 md:mx-20">
-        <h1 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)]">
+        <h1 className="flex items-center text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)]">
+          <img
+            src={logoSrc}
+            alt={mode === "degen" ? "Degen logo" : "Celo logo"}
+            className="w-5 h-5 mr-2"
+          />
           {title}
         </h1>
         <div className="flex items-center gap-2">

--- a/src/components/main/LoadingSpinner.tsx
+++ b/src/components/main/LoadingSpinner.tsx
@@ -10,12 +10,12 @@ export default function LoadingSpinner({
 }: LoadingSpinnerProps) {
   if (isSDKLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-emerald-100 to-amber-100 dark:from-emerald-950 dark:to-amber-950">
+      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-[var(--gradient-from)] to-[var(--gradient-to)]">
         <motion.div
           animate={{ rotate: 360, scale: [1, 1.2, 1] }}
           transition={{ repeat: Infinity, duration: 1.5, ease: "easeInOut" }}
         >
-          <Home className="w-12 h-12 text-emerald-500 dark:text-emerald-300" />
+          <Home className="w-12 h-12" style={{ color: "var(--primary)" }} />
         </motion.div>
       </div>
     );
@@ -26,7 +26,7 @@ export default function LoadingSpinner({
       <motion.div
         animate={{ rotate: 360 }}
         transition={{ repeat: Infinity, duration: 1, ease: "linear" }}
-        className="w-8 h-8 border-4 border-emerald-500 border-t-transparent rounded-full"
+        className="w-8 h-8 border-4 border-[var(--primary)] border-t-transparent rounded-full"
       />
     </div>
   );

--- a/src/components/main/Welcome-Modal.tsx
+++ b/src/components/main/Welcome-Modal.tsx
@@ -24,9 +24,9 @@ export default function WelcomeModal({
       <DialogContent className="bg-white dark:bg-gray-900 rounded-2xl border-0 shadow-xl p-6 max-w-md">
         <DialogHeader>
           <div className="flex justify-center mb-4">
-            <div className="bg-emerald-100 dark:bg-emerald-900 p-3 rounded-full">
-              <Trophy className="w-8 h-8 text-emerald-600 dark:text-emerald-300" />
-            </div>
+          <div className="p-3 rounded-full bg-[var(--primary)]/20">
+            <Trophy className="w-8 h-8" style={{ color: "var(--primary)" }} />
+          </div>
           </div>
           <DialogTitle className="text-2xl font-bold text-center text-gray-900 dark:text-white">
             Welcome to Bank of Celo!
@@ -41,7 +41,7 @@ export default function WelcomeModal({
         <div className="mt-6 flex flex-col gap-3">
           <Button
             onClick={onClose}
-            className="w-full bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-700 hover:to-emerald-600 text-white rounded-lg py-3 shadow-md"
+            className="w-full bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] hover:opacity-90 text-white rounded-lg py-3 shadow-md"
           >
             Get Started
           </Button>

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -52,7 +52,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const [activeTab, setActiveTab] = useState("home");
 
   const { mode } = useChainMode();
-  const dynamicTitle = mode === "degen" ? "Bank of Degen" : title;
+  const dynamicTitle = title;
   const { address: bankAddress, abi: bankAbi } = useBankContract();
   const chainId = useChainId();
   const targetChain = mode === "degen" ? base : celo;

--- a/src/components/tabs/rewards/bottom-sheets/daily-check-ins/index.tsx
+++ b/src/components/tabs/rewards/bottom-sheets/daily-check-ins/index.tsx
@@ -20,10 +20,8 @@ import {
   useSwitchChain,
   useSendTransaction,
 } from "wagmi";
-import {
-  CELO_CHECK_IN_CONTRACT_ADDRESS,
-  CELO_CHECK_IN_ABI,
-} from "~/lib/constants";
+import { useCheckinContract } from "~/hooks/contracts";
+import { useChainMode } from "~/app/chain-mode/context";
 import { encodeFunctionData, formatEther, parseEther, parseUnits } from "viem";
 import { getDataSuffix, submitReferral } from "@divvi/referral-sdk";
 import sdk from "@farcaster/frame-sdk";
@@ -52,6 +50,7 @@ interface DashboardData {
 }
 
 const CELO_CHAIN_ID = 42220;
+const BASE_CHAIN_ID = 8453;
 
 export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
   isOpen,
@@ -62,6 +61,11 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
   const { writeContractAsync, isPending: isTxPending } = useWriteContract();
   const { switchChainAsync } = useSwitchChain();
   const { sendTransactionAsync } = useSendTransaction();
+  const { mode } = useChainMode();
+  const targetChainId = mode === "degen" ? BASE_CHAIN_ID : CELO_CHAIN_ID;
+  const { address: CHECK_IN_CONTRACT_ADDRESS, abi: CHECK_IN_ABI } =
+    useCheckinContract();
+  const tokenSymbol = mode === "degen" ? "DEGEN" : "CELO";
 
   const [dashboardData, setDashboardData] = useState<DashboardData | null>(
     null,
@@ -72,7 +76,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
   const [checkInStatus, setCheckInStatus] = useState<boolean[]>([]);
   const [fid, setFid] = useState<number | null>(null);
 
-  const isCorrectChain = chainId === CELO_CHAIN_ID;
+  const isCorrectChain = chainId === targetChainId;
   const CHECK_IN_FEE = dashboardData?.currentFee || parseEther("0.001");
   const currentDay = dashboardData?.currentDay
     ? Number(dashboardData.currentDay)
@@ -113,8 +117,8 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
 
     try {
       const data: any = (await publicClient.readContract({
-        address: CELO_CHECK_IN_CONTRACT_ADDRESS,
-        abi: CELO_CHECK_IN_ABI,
+        address: CHECK_IN_CONTRACT_ADDRESS,
+        abi: CHECK_IN_ABI,
         functionName: "getUserDashboard",
         args: [address],
       })) as DashboardData;
@@ -124,8 +128,8 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
 
       // Get check-in status for all days
       const status = (await publicClient.readContract({
-        address: CELO_CHECK_IN_CONTRACT_ADDRESS,
-        abi: CELO_CHECK_IN_ABI,
+        address: CHECK_IN_CONTRACT_ADDRESS,
+        abi: CHECK_IN_ABI,
         functionName: "getUserCheckInStatus",
         args: [address],
       })) as boolean[];
@@ -194,7 +198,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
 
   const handleCheckin = async () => {
     if (!address || !publicClient || !dashboardData) {
-      toast.error("Please connect wallet and switch to Celo Network");
+      toast.error("Please connect wallet and switch network");
       return;
     }
 
@@ -208,9 +212,9 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
     setError(null);
 
     try {
-      // Switch to Celo mainnet if needed
+      // Switch to target chain if needed
       if (!isCorrectChain) {
-        await switchChainAsync({ chainId: CELO_CHAIN_ID });
+        await switchChainAsync({ chainId: targetChainId });
       }
 
       // Get signature for check-in
@@ -223,11 +227,11 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
       // Check user's balance for check-in fee
       const balance = await publicClient.getBalance({ address });
       if (balance < CHECK_IN_FEE) {
-        throw new Error(`Insufficient CELO for check-in fee (0.001 CELO)`);
+        throw new Error(`Insufficient funds for check-in fee`);
       }
       // Encode the contract call data
       const checkInData = encodeFunctionData({
-        abi: CELO_CHECK_IN_ABI,
+        abi: CHECK_IN_ABI,
         functionName: "checkIn",
         args: [BigInt(currentDay), signature],
       });
@@ -252,7 +256,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
       const combinedData = (checkInData + dataSuffix) as `0x${string}`;
       // Call checkIn
       const hash = await sendTransactionAsync({
-        to: CELO_CHECK_IN_CONTRACT_ADDRESS,
+        to: CHECK_IN_CONTRACT_ADDRESS,
         data: combinedData,
         value: CHECK_IN_FEE,
         maxFeePerGas: parseUnits("100", 9),
@@ -263,7 +267,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
       try {
         await submitReferral({
           txHash: hash,
-          chainId: CELO_CHAIN_ID,
+          chainId: targetChainId,
         });
       } catch (diviError) {
         console.error("Divi submitReferral error:", diviError);
@@ -304,7 +308,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
       console.log("Signature response:", signature);
       // Encode the contract call data
       const claimData = encodeFunctionData({
-        abi: CELO_CHECK_IN_ABI,
+        abi: CHECK_IN_ABI,
         functionName: "claimReward",
         args: [BigInt(fid), signature],
       });
@@ -330,7 +334,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
 
       // Call claimReward
       const hash = await sendTransactionAsync({
-        to: CELO_CHECK_IN_CONTRACT_ADDRESS,
+        to: CHECK_IN_CONTRACT_ADDRESS,
         data: combinedData,
         maxFeePerGas: parseUnits("100", 9),
         maxPriorityFeePerGas: parseUnits("100", 9),
@@ -378,12 +382,12 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
             <span>
               Transaction successful!{" "}
               <a
-                href={`https://celoscan.io/tx/${txHash}`}
+                href={`${mode === "degen" ? "https://basescan.org" : "https://celoscan.io"}/tx/${txHash}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline"
               >
-                View on CeloScan
+                View on Explorer
               </a>
             </span>
           </div>
@@ -398,14 +402,14 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
 
           <div className="w-full bg-gray-800 rounded-full h-2.5 mb-2">
             <div
-              className="bg-gradient-to-r from-blue-500 to-blue-600 h-2.5 rounded-full"
+              className="bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] h-2.5 rounded-full"
               style={{ width: `${progressPercentage}%` }}
             />
           </div>
 
           <div className="flex justify-between text-sm text-gray-400">
             <span>{userCheckIns}/7 days checked in</span>
-            <span>{currentReward} CELO reward</span>
+            <span>{currentReward} {tokenSymbol} reward</span>
           </div>
         </div>
 
@@ -418,13 +422,13 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
                 key={index}
                 className={`flex flex-col items-center p-2 rounded-lg ${
                   checkInStatus[index]
-                    ? "bg-blue-500/20 border border-blue-500/30"
+                    ? "bg-[var(--primary)]/20 border border-[var(--primary)]/30"
                     : "bg-gray-800/50 border border-gray-700"
                 }`}
               >
                 <span className="text-xs text-gray-300">Day {index + 1}</span>
                 {checkInStatus[index] ? (
-                  <CheckCircle2 className="w-4 h-4 text-blue-400 mt-1" />
+                  <CheckCircle2 className="w-4 h-4 mt-1" style={{ color: "var(--primary)" }} />
                 ) : (
                   <div className="w-4 h-4 rounded-full bg-gray-700 mt-1" />
                 )}
@@ -436,10 +440,10 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
         {/* Action Buttons */}
         {!isCorrectChain ? (
           <Button
-            onClick={() => switchChainAsync({ chainId: CELO_CHAIN_ID })}
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 rounded-lg font-medium"
+            onClick={() => switchChainAsync({ chainId: targetChainId })}
+            className="w-full bg-[var(--primary)] hover:opacity-90 text-white py-3 rounded-lg font-medium"
           >
-            Switch to Celo Network
+            Switch Network
           </Button>
         ) : isLoading ? (
           <Button disabled className="w-full py-3 rounded-lg">
@@ -453,7 +457,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
         ) : !hasCheckedInToday ? (
           <Button
             onClick={handleCheckin}
-            className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white py-3 rounded-lg font-medium flex items-center justify-center gap-2"
+            className="w-full bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] hover:opacity-90 text-white py-3 rounded-lg font-medium flex items-center justify-center gap-2"
           >
             <CheckCircle2 className="w-5 h-5" />
             Check In for Day {currentDay}
@@ -468,10 +472,10 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
         {canClaimReward && (
           <Button
             onClick={handleClaimReward}
-            className="w-full bg-gradient-to-r from-emerald-600 to-emerald-700 hover:from-emerald-700 hover:to-emerald-800 text-white py-3 rounded-lg font-medium flex items-center justify-center gap-2 animate-pulse"
+            className="w-full bg-gradient-to-r from-[var(--gradient-from)] to-[var(--gradient-to)] hover:opacity-90 text-white py-3 rounded-lg font-medium flex items-center justify-center gap-2 animate-pulse"
           >
             <Gift className="w-5 h-5" />
-            Claim {currentReward} CELO Reward
+            Claim {currentReward} {tokenSymbol} Reward
           </Button>
         )}
 
@@ -491,7 +495,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
         <div className="bg-gray-900/50 rounded-xl p-4 border border-gray-800">
           <div className="flex items-center justify-between mb-2">
             <h3 className="font-medium text-gray-300">Current Round</h3>
-            <span className="text-sm text-blue-400">#{currentRoundNumber}</span>
+            <span className="text-sm" style={{ color: "var(--primary)" }}>#{currentRoundNumber}</span>
           </div>
 
           <div className="flex items-center justify-between text-sm text-gray-400 mb-1">
@@ -503,7 +507,7 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
 
           <div className="flex items-center justify-between text-sm text-gray-400">
             <span>Fee</span>
-            <span>0.001 CELO/day</span>
+            <span>0.001 {tokenSymbol}/day</span>
           </div>
         </div>
 
@@ -512,19 +516,19 @@ export const DailyCheckinSheet: React.FC<DailyCheckinSheetProps> = ({
           <h3 className="font-medium text-gray-300 mb-2">How It Works</h3>
           <ul className="space-y-2 text-sm text-gray-400">
             <li className="flex items-start gap-2">
-              <ChevronRight className="w-4 h-4 mt-0.5 text-blue-400 flex-shrink-0" />
-              <span>Check in daily (0.001 CELO fee per check-in)</span>
+              <ChevronRight className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: "var(--primary)" }} />
+              <span>Check in daily (0.001 {tokenSymbol} fee per check-in)</span>
             </li>
             <li className="flex items-start gap-2">
-              <ChevronRight className="w-4 h-4 mt-0.5 text-blue-400 flex-shrink-0" />
-              <span>Complete all 7 days to claim your CELO reward</span>
+              <ChevronRight className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: "var(--primary)" }} />
+              <span>Complete all 7 days to claim your {tokenSymbol} reward</span>
             </li>
             <li className="flex items-start gap-2">
-              <ChevronRight className="w-4 h-4 mt-0.5 text-blue-400 flex-shrink-0" />
+              <ChevronRight className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: "var(--primary)" }} />
               <span>Rewards are distributed at the end of each round</span>
             </li>
             <li className="flex items-start gap-2">
-              <ChevronRight className="w-4 h-4 mt-0.5 text-blue-400 flex-shrink-0" />
+              <ChevronRight className="w-4 h-4 mt-0.5 flex-shrink-0" style={{ color: "var(--primary)" }} />
               <span>Connect your Farcaster account to claim rewards</span>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- update theme styles to use CSS variables
- add header logos based on chain mode
- show new logo and theme colors in navigation and loading states
- switch daily check-in contract based on selected chain

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686282508b40832887fbc80ac297c9e6