### PR TITLE
Update connect button gradient

### DIFF
--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -69,11 +69,11 @@ export default function Header({
               <Button
                 onClick={onDisconnect}
                 className={cn(
-                  "text-xs font-medium flex items-center rounded-full shadow-lg transition-all duration-300 ease-in-out transform hover:scale-105 border",
+                  "text-xs font-medium flex items-center rounded-full shadow-lg transition-all duration-300 ease-in-out transform hover:scale-105 border text-white",
                   "px-2.5 py-1.5 md:px-4 md:py-2.5",
                   mode === "celo"
-                    ? "bg-white/90 dark:bg-emerald-900/90 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-800 hover:shadow-emerald-200/50 dark:hover:shadow-emerald-900/50"
-                    : "bg-white/90 dark:bg-purple-900/90 text-purple-700 dark:text-purple-300 border-purple-200 dark:border-purple-700 hover:bg-purple-50 dark:hover:bg-purple-800 hover:shadow-purple-200/50 dark:hover:shadow-purple-900/50"
+                    ? "bg-gradient-to-r from-yellow-400 to-emerald-500 hover:from-yellow-500 hover:to-emerald-600 border-yellow-400 hover:shadow-yellow-200/50"
+                    : "bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 border-purple-400 hover:shadow-purple-200/50"
                 )}
                 aria-label="Disconnect wallet"
               >
@@ -105,7 +105,7 @@ export default function Header({
                 "text-xs font-medium flex items-center rounded-full shadow-lg transition-all duration-300 ease-in-out transform hover:scale-105 border text-white",
                 "px-3 py-1.5 md:px-5 md:py-2.5",
                 mode === "celo"
-                  ? "bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 border-emerald-400 hover:shadow-emerald-200/50"
+                  ? "bg-gradient-to-r from-yellow-400 to-emerald-500 hover:from-yellow-500 hover:to-emerald-600 border-yellow-400 hover:shadow-yellow-200/50"
                   : "bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700 border-purple-400 hover:shadow-purple-200/50"
               )}
               aria-label="Connect wallet"


### PR DESCRIPTION
## Summary
- tweak gradient for Header connect button
- use same gradient in connected wallet state

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba3937e4c8328898a49d5c43dc523