### PR TITLE
Add cashback UI

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import type { Session } from "next-auth";
 import { SessionProvider } from "next-auth/react";
 import { FrameProvider } from "~/components/providers/FrameProvider";
+import { CashbackProvider } from "~/components/providers/CashbackProvider";
 import { ConvexClientProvider } from "./ConvexClientProvider";
 import { ChainModeProvider } from "./chain-mode/context";
 
@@ -26,7 +27,9 @@ export function Providers({
       <WagmiProvider>
         <ChainModeProvider>
           <FrameProvider>
-            <ConvexClientProvider>{children}</ConvexClientProvider>
+            <CashbackProvider>
+              <ConvexClientProvider>{children}</ConvexClientProvider>
+            </CashbackProvider>
           </FrameProvider>
         </ChainModeProvider>
       </WagmiProvider>

--- a/src/components/main/BottomNavigation.tsx
+++ b/src/components/main/BottomNavigation.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { Home, Send, Trophy, Briefcase } from "lucide-react";
+import { Home, Send, Trophy, Briefcase, DollarSign } from "lucide-react";
 import { useChainMode } from "~/app/chain-mode/context";
 
 interface BottomNavigationProps {
@@ -15,6 +15,7 @@ const tabs = [
     icon: <Briefcase className="w-5 h-5" />,
     label: "Services",
   },
+  { id: "cashback", icon: <DollarSign className="w-5 h-5" />, label: "Cashback" },
   { id: "rewards", icon: <Trophy className="w-5 h-5" />, label: "Rewards" },
 ];
 

--- a/src/components/main/TabContent.tsx
+++ b/src/components/main/TabContent.tsx
@@ -3,6 +3,7 @@ import HomeTab from "~/components/tabs/HomeTab";
 import TransactTab from "~/components/tabs/TransactTab";
 import Rewards from "~/components/tabs/rewards";
 import ServicesTab from "../tabs/services";
+import CashbackTab from "../tabs/CashbackTab";
 
 interface VaultStatus {
   currentBalance: string;
@@ -77,6 +78,7 @@ export default function TabContent({
           />
         )}
         {activeTab === "rewards" && <Rewards />}
+        {activeTab === "cashback" && <CashbackTab />}
       </motion.div>
     </AnimatePresence>
   );

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -33,6 +33,7 @@ import BottomNavigation from "./BottomNavigation";
 import { useSearchParams } from "next/navigation";
 import { useChainMode } from "~/app/chain-mode/context";
 import { cn } from "~/lib/utils";
+import { useCashback } from "~/components/providers/CashbackProvider";
 
 export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const { address, isConnected, chain } = useAccount();
@@ -44,6 +45,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const { writeContract, isPending } = useWriteContract();
   const publicClient = usePublicClient();
   const { isSDKLoaded, context } = useFrame();
+  const { optedIn, addCashback } = useCashback();
   const searchParams = useSearchParams();
 
   const [customSearchParams, setCustomSearchParams] =
@@ -246,6 +248,10 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
           `Donation successful! Transaction hash: ${hash.slice(0, 6)}...`,
         );
         fetchContractData();
+        if (optedIn) {
+          const amt = parseFloat(amount);
+          if (!isNaN(amt)) addCashback(amt * 0.01);
+        }
 
         // 6. Report to Divi in a separate try-catch
         try {
@@ -271,7 +277,20 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         );
       }
     },
-    [isCorrectChain, sendTransactionAsync, targetChain.id, fetchContractData, publicClient, mode, address, bankAddress, bankAbi, writeContract],
+    [
+      isCorrectChain,
+      sendTransactionAsync,
+      targetChain.id,
+      fetchContractData,
+      publicClient,
+      mode,
+      address,
+      bankAddress,
+      bankAbi,
+      writeContract,
+      optedIn,
+      addCashback,
+    ],
   );
 
   // Show loading spinner if SDK is not loaded

--- a/src/components/providers/CashbackProvider.tsx
+++ b/src/components/providers/CashbackProvider.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, useContext } from "react";
+
+interface CashbackContextProps {
+  optedIn: boolean;
+  cashback: number;
+  optIn: () => void;
+  addCashback: (amount: number) => void;
+  claim: () => void;
+}
+
+const CashbackContext = React.createContext<CashbackContextProps | undefined>(
+  undefined,
+);
+
+export const useCashback = () => {
+  const ctx = useContext(CashbackContext);
+  if (!ctx) {
+    throw new Error("useCashback must be used within CashbackProvider");
+  }
+  return ctx;
+};
+
+export function CashbackProvider({ children }: { children: React.ReactNode }) {
+  const [optedIn, setOptedIn] = useState(false);
+  const [cashback, setCashback] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedOpt = localStorage.getItem("cashbackOptIn");
+    const storedBal = localStorage.getItem("cashbackBalance");
+    setOptedIn(storedOpt === "true");
+    setCashback(storedBal ? parseFloat(storedBal) : 0);
+  }, []);
+
+  const persist = useCallback((opt: boolean, bal: number) => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem("cashbackOptIn", String(opt));
+    localStorage.setItem("cashbackBalance", bal.toString());
+  }, []);
+
+  const optIn = useCallback(() => {
+    setOptedIn(true);
+    persist(true, cashback);
+  }, [persist, cashback]);
+
+  const addCashback = useCallback(
+    (amount: number) => {
+      setCashback((prev) => {
+        const val = prev + amount;
+        persist(true, val);
+        return val;
+      });
+    },
+    [persist],
+  );
+
+  const claim = useCallback(() => {
+    setCashback(0);
+    persist(true, 0);
+  }, [persist]);
+
+  const value = { optedIn, cashback, optIn, addCashback, claim };
+
+  return (
+    <CashbackContext.Provider value={value}>{children}</CashbackContext.Provider>
+  );
+}

--- a/src/components/tabs/CashbackTab.tsx
+++ b/src/components/tabs/CashbackTab.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Gift, DollarSign, Plus } from "lucide-react";
+import { motion } from "framer-motion";
+import { Button } from "~/components/ui/Button";
+import { useCashback } from "~/components/providers/CashbackProvider";
+
+export default function CashbackTab() {
+  const { optedIn, cashback, optIn, claim, addCashback } = useCashback();
+
+  return (
+    <div className="min-h-screen bg-white text-gray-900 rounded-md relative overflow-hidden p-6 pb-32">
+      {!optedIn ? (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center space-y-4"
+        >
+          <h2 className="text-xl font-semibold">Cashback Rewards</h2>
+          <p className="text-sm text-gray-600">
+            Opt in to start earning cashback on your transactions.
+          </p>
+          <Button
+            onClick={() => optIn()}
+            className="mx-auto flex items-center gap-2 px-6"
+          >
+            <Gift className="w-4 h-4" /> Opt In
+          </Button>
+        </motion.div>
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-6"
+        >
+          <div className="text-center">
+            <p className="text-sm text-gray-500">Claimable Cashback</p>
+            <p className="text-3xl font-bold mt-1">
+              {cashback.toFixed(2)} CELO
+            </p>
+          </div>
+          <Button
+            onClick={() => claim()}
+            className="w-full flex items-center justify-center gap-2"
+          >
+            <DollarSign className="w-4 h-4" /> Claim
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => addCashback(0.1)}
+            className="w-full flex items-center justify-center gap-2 text-xs"
+          >
+            <Plus className="w-4 h-4" /> Add Dummy Cashback
+          </Button>
+        </motion.div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `CashbackProvider` context for local cashback tracking
- include `CashbackProvider` in app providers
- create `CashbackTab` UI for opt-in and claiming
- wire up cashback tab in navigation and tab content
- increment cashback on donations

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687276de15708328b293fad90d46e435