### PR TITLE
Fix donation success timing

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -336,6 +336,8 @@ const handleDonate = async (amount: string) => {
     // 8. Send the transaction
     const hash = await sendTransactionAsync(transactionParams);
 
+    await publicClient.waitForTransactionReceipt({ hash });
+
     // 9. Show success toast and update contract data
     toast.success(`Donation successful! Transaction hash: ${hash.slice(0, 6)}...`);
     fetchContractData();

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -199,12 +199,13 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
               args: [bankAddress, amountParsed],
             });
           }
-          await writeContract({
+          const hash = await writeContract({
             address: bankAddress,
             abi: bankAbi,
             functionName: "donate",
             args: [amountParsed],
           });
+          await publicClient.waitForTransactionReceipt({ hash });
           toast.success("Donation successful!");
           fetchContractData();
           return;
@@ -241,7 +242,9 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
           maxPriorityFeePerGas: parseUnits("100", 9),
         });
 
-        // 5. Show success toast and update contract data immediately
+        await publicClient.waitForTransactionReceipt({ hash });
+
+        // 5. Show success toast and update contract data
         toast.success(
           `Donation successful! Transaction hash: ${hash.slice(0, 6)}...`,
         );

--- a/src/components/main/index.tsx
+++ b/src/components/main/index.tsx
@@ -41,7 +41,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
   const { switchChain, isPending: isSwitchChainPending } = useSwitchChain();
   const { data: session, status } = useSession();
   const { sendTransactionAsync } = useSendTransaction();
-  const { writeContract, isPending } = useWriteContract();
+  const { writeContractAsync, isPending } = useWriteContract();
   const publicClient = usePublicClient();
   const { isSDKLoaded, context } = useFrame();
   const searchParams = useSearchParams();
@@ -192,14 +192,14 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
             args: [address, bankAddress],
           })) as bigint;
           if (allowance < amountParsed) {
-            await writeContract({
+            await writeContractAsync({
               address: tokenAddress,
               abi: ERC20_ABI,
               functionName: "approve",
               args: [bankAddress, amountParsed],
             });
           }
-          const hash = await writeContract({
+          const hash = await writeContractAsync({
             address: bankAddress,
             abi: bankAbi,
             functionName: "donate",
@@ -274,7 +274,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
         );
       }
     },
-    [isCorrectChain, sendTransactionAsync, targetChain.id, fetchContractData, publicClient, mode, address, bankAddress, bankAbi, writeContract],
+    [isCorrectChain, sendTransactionAsync, targetChain.id, fetchContractData, publicClient, mode, address, bankAddress, bankAbi, writeContractAsync],
   );
 
   // Show loading spinner if SDK is not loaded


### PR DESCRIPTION
## Summary
- wait for transaction confirmations before showing donation success toasts

## Testing
- `npx next lint` *(fails: E403 due to missing internet)*

------
https://chatgpt.com/codex/tasks/task_e_68739c1795448328823dee1e62dd650e