### PR TITLE
feat: show loader during donation

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -69,6 +69,7 @@ export default function Main({ title = "Bank of Celo" }: { title?: string }) {
     return true;
   });
   const [isLoading, setIsLoading] = useState(false);
+  const [isDonating, setIsDonating] = useState(false);
   const [claimCooldown, setClaimCooldown] = useState<number>(0);
   const [lastClaimAt, setLastClaimAt] = useState<number>(0);
   const [maxClaim, setMaxClaim] = useState<string>("0");
@@ -225,6 +226,7 @@ const handleDonate = async (amount: string) => {
     return;
   }
 
+  setIsDonating(true);
   try {
     let donateData: `0x${string}`;
     let transactionParams: Parameters<typeof sendTransactionAsync>[0];
@@ -368,6 +370,8 @@ const handleDonate = async (amount: string) => {
     );
     // Log detailed error for debugging
     if (error.cause) console.error("Detailed error cause:", error.cause);
+  } finally {
+    setIsDonating(false);
   }
 };
   const handleConnect = () => {
@@ -493,6 +497,7 @@ const handleDonate = async (amount: string) => {
                 lastClaimAt={lastClaimAt}
                 isCorrectChain={isCorrectChain}
                 isPending={isPending}
+                isDonating={isDonating}
               />
             )}
             {activeTab === "jackpot" && (

--- a/src/components/tabs/TransactTab.tsx
+++ b/src/components/tabs/TransactTab.tsx
@@ -43,6 +43,7 @@ interface TransactTabProps {
   availableForClaim: string;
   isCorrectChain: boolean;
   isPending: boolean;
+  isDonating: boolean;
 }
 
 interface NeynarResponse {
@@ -58,6 +59,7 @@ export default function TransactTab({
   lastClaimAt = 0,
   isCorrectChain,
   isPending,
+  isDonating,
   availableForClaim,
   vaultBalance,
 }: TransactTabProps) {
@@ -637,11 +639,11 @@ const handleClaim = async () => {
             </div>
             <Button
               onClick={handleSubmit}
-              disabled={isPending || !amount}
+              disabled={isPending || isDonating || !amount}
               className={getDonateButtonClasses()}
               aria-label={`Donate ${currency}`}
             >
-              {isPending ? (
+              {isPending || isDonating ? (
                 <Loader2 className="w-5 h-5 animate-spin" />
               ) : (
                 <div className="flex items-center justify-center gap-2">


### PR DESCRIPTION
## Summary
- track donation progress with new `isDonating` state
- show loader and disable donate button while donation or approval is pending

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c46d1c8c4832885a413e97952eb1a